### PR TITLE
Fix docker port

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -17,7 +17,7 @@ module.exports.spawn = function ({ command = 'java', path = null, port = null, s
 
         args.push(
             '--publish',
-            `8000:${port === null ? '8000' : port.toString()}`,
+            `${port === null ? '8000' : port.toString()}:8000`,
             '--rm',
             'amazon/dynamodb-local:latest',
             '-jar',


### PR DESCRIPTION
When using docker the current code maps port 8000 on localhost to the specified port in the container.  This should be the other way around or it won't actually connect.