### PR TITLE
Improve logging & possibly fix issues w/ Node.js 17+

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -48,6 +48,7 @@ module.exports.spawn = function ({ command = 'java', path = null, port = null, s
     }
 
     return spawn(command, args, {
-        cwd: __dirname
+        cwd: __dirname,
+        stdio: 'inherit' // use parent's: "stdin", "stdout", "stderr" streams for better logging
     });
 };

--- a/src/module.js
+++ b/src/module.js
@@ -49,6 +49,6 @@ module.exports.spawn = function ({ command = 'java', path = null, port = null, s
 
     return spawn(command, args, {
         cwd: __dirname,
-        stdio: 'inherit' // use parent's: "stdin", "stdout", "stderr" streams for better logging
+        stdio: 'inherit'
     });
 };


### PR DESCRIPTION
DynamoDB doesn't spin up for me w/ Node.js 17+, unless `stdio: 'inherit'` is set.

But, primarily, this PR should improve logging of what is being spawned.
Users should start seeing similar to the following in their CLI:

<img width="449" alt="Screenshot 2022-12-17 at 2 11 50 AM" src="https://user-images.githubusercontent.com/9992724/208232564-8bb63abf-0d0b-4c2d-8996-c08b92743204.png">
