### PR TITLE
Lock Docker image version to the version of the JAR included in the package

### DIFF
--- a/src/module.js
+++ b/src/module.js
@@ -19,7 +19,7 @@ module.exports.spawn = function ({ command = 'java', path = null, port = null, s
             '--publish',
             `${port === null ? '8000' : port.toString()}:8000`,
             '--rm',
-            'amazon/dynamodb-local:latest',
+            'amazon/dynamodb-local:1.20.0',
             '-jar',
             'DynamoDBLocal.jar'
         );


### PR DESCRIPTION
Since the JAR versioned packaged with the library is `1.20.0`, it could be advisable to lock the version used when using Docker to the same version.